### PR TITLE
chore: implement build requirements for label matching finding ARN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN --mount=target=. \
 FROM gcr.io/distroless/static-debian12:nonroot AS image
 WORKDIR /
 COPY --from=build /function /function
+
+COPY package.yaml /package.yaml
 EXPOSE 9443
 USER nonroot:nonroot
 ENTRYPOINT ["/function"]

--- a/fn.go
+++ b/fn.go
@@ -137,7 +137,7 @@ func buildRequirements(_ *v1alpha1.Input, xr *resource.Composite) *fnv1.Requirem
 							MatchLabels: &fnv1.MatchLabels{
 								Labels: map[string]string{
 									"crossplane.io/claim-name":      user.(string),
-									"crossplane.io/claim-namespace": xr.Resource.Unstructured.GetNamespace(),
+									"crossplane.io/claim-namespace": xr.Resource.Unstructured.GetLabels()["crossplane.io/claim-namespace"],
 									"s3.statnett.no/account-name":   spec["accountRef"].(map[string]any)["name"].(string),
 								},
 							},

--- a/fn_test.go
+++ b/fn_test.go
@@ -49,8 +49,12 @@ func TestRunFunction(t *testing.T) {
 									"kind":       structpb.NewStringValue("Input"),
 									"metadata": structpb.NewStructValue(&structpb.Struct{
 										Fields: map[string]*structpb.Value{
-											"name":      structpb.NewStringValue("test"),
-											"namespace": structpb.NewStringValue("test"),
+											"name": structpb.NewStringValue("test"),
+											"labels": structpb.NewStructValue(&structpb.Struct{
+												Fields: map[string]*structpb.Value{
+													"crossplane.io/claim-namespace": structpb.NewStringValue("test"),
+												},
+											}),
 										},
 									}),
 									"spec": structpb.NewStructValue(&structpb.Struct{
@@ -125,13 +129,13 @@ func TestRunFunction(t *testing.T) {
 									"kind":       structpb.NewStringValue("Bucket"),
 									"metadata": structpb.NewStructValue(&structpb.Struct{
 										Fields: map[string]*structpb.Value{
-											"name":      structpb.NewStringValue("test"),
+											"name": structpb.NewStringValue("test"),
+											"labels": structpb.NewStructValue(&structpb.Struct{
+												Fields: map[string]*structpb.Value{
+													"crossplane.io/claim-namespace": structpb.NewStringValue("test"),
+												},
+											}),
 										},
-										"labels": structpb.NewStructValue(&structpb.Struct{
-											Fields: map[string]*structpb.Value{
-												"crossplane.io/claim-namespace":      structpb.NewStringValue("test"),
-											},
-										}),
 									}),
 									"spec": structpb.NewStructValue(&structpb.Struct{
 										Fields: map[string]*structpb.Value{

--- a/fn_test.go
+++ b/fn_test.go
@@ -42,6 +42,48 @@ func TestRunFunction(t *testing.T) {
 						"apiVersion": "s3-user-arn.fn.crossplane.io/v1alpha1",
 						"kind": "Input"
 					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"apiVersion": structpb.NewStringValue("s3-user-arn.fn.crossplane.io/v1alpha1"),
+									"kind":       structpb.NewStringValue("Input"),
+									"metadata": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"name":      structpb.NewStringValue("test"),
+											"namespace": structpb.NewStringValue("test"),
+										},
+									}),
+									"spec": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"accountRef": structpb.NewStructValue(&structpb.Struct{
+												Fields: map[string]*structpb.Value{
+													"name": structpb.NewStringValue("test"),
+												},
+											}),
+											"permissions": structpb.NewListValue(&structpb.ListValue{
+												Values: []*structpb.Value{
+													structpb.NewStructValue(&structpb.Struct{
+														Fields: map[string]*structpb.Value{
+															"principals": structpb.NewListValue(&structpb.ListValue{
+																Values: []*structpb.Value{
+																	structpb.NewStructValue(&structpb.Struct{
+																		Fields: map[string]*structpb.Value{
+																			"user": structpb.NewStringValue("test"),
+																		},
+																	}),
+																},
+															}),
+														},
+													}),
+												},
+											}),
+										},
+									}),
+								},
+							},
+						},
+					},
 				},
 			},
 			want: want{

--- a/fn_test.go
+++ b/fn_test.go
@@ -121,13 +121,17 @@ func TestRunFunction(t *testing.T) {
 						Composite: &fnv1.Resource{
 							Resource: &structpb.Struct{
 								Fields: map[string]*structpb.Value{
-									"apiVersion": structpb.NewStringValue("s3-user-arn.fn.crossplane.io/v1alpha1"),
-									"kind":       structpb.NewStringValue("Input"),
+									"apiVersion": structpb.NewStringValue("s3.statnett.no/v1alpha1"),
+									"kind":       structpb.NewStringValue("Bucket"),
 									"metadata": structpb.NewStructValue(&structpb.Struct{
 										Fields: map[string]*structpb.Value{
 											"name":      structpb.NewStringValue("test"),
-											"namespace": structpb.NewStringValue("test"),
 										},
+										"labels": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												"crossplane.io/claim-namespace":      structpb.NewStringValue("test"),
+											},
+										}),
 									}),
 									"spec": structpb.NewStructValue(&structpb.Struct{
 										Fields: map[string]*structpb.Value{

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: meta.pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    meta.crossplane.io/description: "a"
+    meta.crossplane.io/license: "a"
+    meta.crossplane.io/maintainer: "a"
+    meta.crossplane.io/readme: "a"
+    meta.crossplane.io/source: "a"
+  creationTimestamp: null
+  name: s3-user-arn
+spec: {}


### PR DESCRIPTION
This PR implements a Crossplane Function which, when used in a composition, allows AWS S3 Users to be referred to in an `s3.statnett.no/XBucket` without a need for AWS ARN notation.