### PR TITLE
feat: lookup user in any tenant/account - not just same namespace

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -141,7 +141,7 @@ func buildRequirements(_ *v1alpha1.Input, xr *resource.Composite, context *struc
 						account = a.(string)
 					}
 
-					key := fmt.Sprintf("%s %s %s", observedTenant, observedAccount, user)
+					key := fmt.Sprintf("%s %s %s", tenant, account, user)
 					extraResources[key] = &fnv1.ResourceSelector{
 						ApiVersion: "iam.aws.upbound.io/v1beta1",
 						Kind:       "User",

--- a/fn_test.go
+++ b/fn_test.go
@@ -46,10 +46,7 @@ func TestRunFunction(t *testing.T) {
 								"apiVersion": "s3.statnett.no/v1alpha1",
 								"kind": "Bucket",
 								"metadata": {
-									"name": "test",
-									"labels": {
-										"crossplane.io/claim-namespace": "test"
-									}
+									"name": "test"
 								},
 								"spec": {
 									"accountRef": {
@@ -68,22 +65,32 @@ func TestRunFunction(t *testing.T) {
 							}`),
 						},
 					},
+					Context: resource.MustStructJSON(`{
+						"apiextensions.crossplane.io/environment": {
+							"tenantName": "tenant"
+						}
+					}`),
 				},
 			},
 			want: want{
 				rsp: &fnv1.RunFunctionResponse{
 					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Context: resource.MustStructJSON(`{
+						"apiextensions.crossplane.io/environment": {
+							"tenantName": "tenant"
+						}
+					}`),
 					Requirements: &fnv1.Requirements{
 						ExtraResources: map[string]*fnv1.ResourceSelector{
-							"test": {
+							"tenant account test": {
 								ApiVersion: "iam.aws.upbound.io/v1beta1",
 								Kind:       "User",
 								Match: &fnv1.ResourceSelector_MatchLabels{
 									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
-											"crossplane.io/claim-name":      "test",
-											"crossplane.io/claim-namespace": "test",
-											"s3.statnett.no/account-name":   "account",
+											"s3.statnett.no/tenant-name":  "tenant",
+											"s3.statnett.no/account-name": "account",
+											"crossplane.io/claim-name":    "test",
 										},
 									},
 								},
@@ -108,10 +115,7 @@ func TestRunFunction(t *testing.T) {
 								"apiVersion": "s3.statnett.no/v1alpha1",
 								"kind": "Bucket",
 								"metadata": {
-									"name": "test",
-									"labels": {
-										"crossplane.io/claim-namespace": "test"
-									}
+									"name": "test"
 								},
 								"spec": {
 									"accountRef": {
@@ -130,8 +134,13 @@ func TestRunFunction(t *testing.T) {
 							}`),
 						},
 					},
+					Context: resource.MustStructJSON(`{
+						"apiextensions.crossplane.io/environment": {
+							"tenantName": "tenant"
+						}
+					}`),
 					ExtraResources: map[string]*fnv1.Resources{
-						"test": {
+						"tenant account test": {
 							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
@@ -157,8 +166,11 @@ func TestRunFunction(t *testing.T) {
 				rsp: &fnv1.RunFunctionResponse{
 					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
 					Context: resource.MustStructJSON(`{
+						"apiextensions.crossplane.io/environment": {
+							"tenantName": "tenant"
+						},
 						"s3-user-arn.fn.crossplane.io": {
-							"test": [
+							"tenant account test": [
 								{
 									"apiVersion": "iam.aws.upbound.io/v1beta1",
 									"kind": "User",
@@ -177,15 +189,15 @@ func TestRunFunction(t *testing.T) {
 					}`),
 					Requirements: &fnv1.Requirements{
 						ExtraResources: map[string]*fnv1.ResourceSelector{
-							"test": {
+							"tenant account test": {
 								ApiVersion: "iam.aws.upbound.io/v1beta1",
 								Kind:       "User",
 								Match: &fnv1.ResourceSelector_MatchLabels{
 									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
-											"crossplane.io/claim-name":      "test",
-											"crossplane.io/claim-namespace": "test",
-											"s3.statnett.no/account-name":   "account",
+											"s3.statnett.no/tenant-name":  "tenant",
+											"s3.statnett.no/account-name": "account",
+											"crossplane.io/claim-name":    "test",
 										},
 									},
 								},

--- a/fn_test.go
+++ b/fn_test.go
@@ -230,7 +230,7 @@ func TestRunFunction(t *testing.T) {
 										{
 											"principals": [
 												{
-											    "tenant": "foo",
+													"tenant": "foo",
 													"account": "bar",
 													"user": "baz"
 												}


### PR DESCRIPTION
To support

```yaml
permissions:
  - principals:
      - tenant: foo
        account: bar
        user: baz
```